### PR TITLE
common_security_tests.d: allow multiple encryption for root password

### DIFF
--- a/cukinia/common_security_tests.d/hardening.conf
+++ b/cukinia/common_security_tests.d/hardening.conf
@@ -11,9 +11,10 @@ as "SEAPATH-00088 - root password was randomized at boot" cukinia_test \
 as "SEAPATH-00089 - root password is randomized at each boot" \
     cukinia_cmd systemctl --quiet is-enabled random-root-passwd.service
 
-# Check that root password is encrypted as sha512
-as "SEAPATH-00091 - root password is encrypted as sha512" \
-    cukinia_cmd grep -Fq 'root:$6$' /etc/shadow
+# Check that root password is encrypted with a cryto at least equivalent as
+# sha512. See man 5 crypt
+as "SEAPATH-00091 - root password is encrypted with a cryto at least equivalent as sha512" \
+    cukinia_cmd grep -Eq 'root:\$[6,y,gy,7,2b]\$' /etc/shadow
 
 # Check that bash timeout variable is read-only and set to 300s
 as "SEAPATH-00092 - bash timeout is set read-only to 300s" cukinia_test \


### PR DESCRIPTION
Support all encryption at least equivalent to SHA512.
See man 5 crypt for more information.