### PR TITLE
security: files: forbid nouser and nogroup files

### DIFF
--- a/cukinia/common_security_tests.d/files.conf
+++ b/cukinia/common_security_tests.d/files.conf
@@ -17,3 +17,6 @@ as "SEAPATH-00049 - Check /etc/ssh/ssh_host_ed25519_key permissions" cukinia_tes
 
 as "SEAPATH-00090 - Check /etc/ssh/ssh_host_rsa_key permissions" cukinia_test \
     "$(stat -c "%a %U %G" /etc/ssh/ssh_host_rsa_key)" == "600 root root"
+
+as "SEAPATH-00176 - All files have a known user and group" \
+    cukinia_test "$(find / -type f,d,l \( -nouser -o -nogroup \) -ls 2>/dev/null)" = ""


### PR DESCRIPTION
Verifies compliance with ANSSI-BP-028 R53

SFL: #8643
Change-Id: I97879f39ae7580ab0a812e6a9313c1bc69f4ed7f
Signed-off-by: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>