### PR TITLE
cukinia-tests: add test for anssi bp-028 r11

### DIFF
--- a/cukinia/common_security_tests.d/kernel.conf
+++ b/cukinia/common_security_tests.d/kernel.conf
@@ -31,3 +31,6 @@ as "SEAPATH-00174 - Randomize kstack offset in on" cukinia_cmd \
 
 as "SEAPATH-00175 - Disable slab usercopy fallback" cukinia_cmd \
     grep -q "slab_common.usercopy_fallback=N" /proc/cmdline
+
+as "ANSSI-BP-028-R11-1 - LSM Yama is enabled" cukinia_cmd \
+	grep -q "security=yama" /proc/cmdline

--- a/cukinia/common_security_tests.d/sysctl.conf
+++ b/cukinia/common_security_tests.d/sysctl.conf
@@ -57,6 +57,8 @@ as "ANSSI-BP-028-R9-9 - Check unprivileged_bpf_disabled is set to 1" cukinia_sys
 
 as "ANSSI-BP-028-R9-10 - Check panic_on_oops is set to 1" cukinia_sysctl kernel.panic_on_oops 1
 
+as "ANSSI-BP-028-R11-2 - Check kernel.yama.ptrace_scope is set to 2" cukinia_sysctl kernel.yama.ptrace_scope 2
+
 as "ANSSI-BP-028-R14-1 - Check suid_dumpable is set to 0" cukinia_sysctl fs.suid_dumpable 0
 
 as "ANSSI-BP-028-R14-2 - Check protected_fifos is set to 2" cukinia_sysctl fs.protected_fifos 2


### PR DESCRIPTION
* Validate kernel.yama.ptrace_scope set to 2 (only processes with CAP_SYS_PTRACE may use ptrace with PTRACE_ATTACH, or through children calling PTRACE_TRACEME)

* Validate LSM yama is enable in boot kernel parameter with security=yama