### PR TITLE
cluster_tests.d/ceph: test cluster have 2 OSDs or more

### DIFF
--- a/cukinia/cluster_tests.d/ceph.conf
+++ b/cukinia/cluster_tests.d/ceph.conf
@@ -23,8 +23,9 @@ as "SEAPATH-00052 - 3 monitors are configured" cukinia_test $? -eq 0
 quorum_out="$(get_ceph_status_field 'out of quorum' || echo fail)"
 as "SEAPATH-00053 - 3 monitors are up" cukinia_test -z "${quorum_out}"
 
-get_ceph_status_field osd | grep -q "2 osds: 2 up"
-as "SEAPATH-00054 - 2 osds are configured and up"  cukinia_test $? -eq 0
+get_ceph_status_field osd | \
+    grep -qE "([2-9][0-9]*|1[0-9]+) osds: ([2-9][0-9]*|1[0-9]+) up"
+as "SEAPATH-00054 - at least 2 osds are configured and up" cukinia_test $? -eq 0
 
 get_ceph_status_field mgr | grep -q "active"
 as "SEAPATH-00055 - a manager is active" cukinia_test $? -eq 0


### PR DESCRIPTION
A SEAPATH cluster must have at least 2 OSDs, but can have more than only 2.