### PR TITLE
cluster_tests: increase RBD snapshot timeout and cosmetic fixes

### DIFF
--- a/cukinia/cluster_tests.d/vm_manager_libvirt.conf
+++ b/cukinia/cluster_tests.d/vm_manager_libvirt.conf
@@ -19,9 +19,11 @@ as "SEAPATH-00065 - list secrets" cukinia_test `/usr/local/bin/libvirt_cmd.py se
 as "SEAPATH-00066 - define VM from a valid configuration" cukinia_cmd \
     /usr/local/bin/libvirt_cmd.py define /usr/share/testdata/vm.xml
 
-as "SEAPATH-00067 - define VM from a valid configuration"
-/usr/local/bin/libvirt_cmd.py define \
+
+/usr/local/bin/libvirt_cmd.py \
+    define \
     /usr/share/testdata/wrong_vm_config.xml 1>/dev/null 2>&1
+as "SEAPATH-00067 - define VM from a valid configuration" \
 cukinia_test $? -ne 0
 
 as "SEAPATH-00068 - list VM" cukinia_test `/usr/local/bin/libvirt_cmd.py list \

--- a/cukinia/cluster_tests.d/vm_manager_pacemaker.conf
+++ b/cukinia/cluster_tests.d/vm_manager_pacemaker.conf
@@ -1,7 +1,7 @@
 # Copyright (C) 2021, RTE (http://www.rte-france.com)
 # SPDX-License-Identifier: Apache-2.0
 
-cukinia_log "$(_colorize yellow "--- est vm_manager module Pacemaker part ---")"
+cukinia_log "$(_colorize yellow "--- Test vm_manager module Pacemaker part ---")"
 
 as "SEAPATH-00071 - Test add VM" cukinia_cmd /usr/local/bin/add_vm.py
 

--- a/cukinia/cluster_tests.d/vm_manager_rbd.conf
+++ b/cukinia/cluster_tests.d/vm_manager_rbd.conf
@@ -11,8 +11,8 @@ as "SEAPATH-00058 - Test namespaces" cukinia_cmd timeout -k 5s 5s /usr/local/bin
 
 as "SEAPATH-00059 - Test metadata" cukinia_cmd timeout -k 5s 5s /usr/local/bin/metadata_rbd.py
 
-as "SEAPATH-00060 - Test snapshots" cukinia_cmd timeout -k 5s 5s /usr/local/bin/purge_rbd.py
+as "SEAPATH-00060 - Test snapshots" cukinia_cmd timeout -k 30s 30s /usr/local/bin/purge_rbd.py
 
-as "SEAPATH-00061 - Test snapshots rollback" cukinia_cmd timeout -k 5s 5s /usr/local/bin/rollback_rbd.py
+as "SEAPATH-00061 - Test snapshots rollback" cukinia_cmd timeout -k 10s 10s /usr/local/bin/rollback_rbd.py
 
 as "SEAPATH-00062 - Test write rbd" cukinia_cmd timeout -k 5s 5s /usr/local/bin/write_rbd.py


### PR DESCRIPTION
Increase some vm_manager RBD tests timeout.
Add missing T at Test in vm_manager_pacemaker.conf.
In vm_manager_libvirt.conf "define VM from a valid configuration" test was not displayed.
