### PR TITLE
security: apt: allow python3-cffi-backend

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf
+++ b/cukinia/common_security_tests.d/apt.conf
@@ -14,6 +14,8 @@ as "ANSSI-BP-028-R59 - Only official apt repositories configured" \
 
 # These packages are essential to seapath
 ESSENTIAL_PACKAGES_SEAPATH="at|\
+audispd-plugins|\
+auditd|\
 bridge-utils|\
 ca-certificates|\
 ceph-base|\

--- a/cukinia/common_security_tests.d/apt.conf
+++ b/cukinia/common_security_tests.d/apt.conf
@@ -54,6 +54,7 @@ ovmf|\
 pacemaker|\
 python3-ceph-argparse|\
 python3-cephfs|\
+python3-cffi-backend|\
 python3-setuptools|\
 qemu-block-extra|\
 qemu-utils|\

--- a/cukinia/common_security_tests.d/apt.conf
+++ b/cukinia/common_security_tests.d/apt.conf
@@ -54,6 +54,7 @@ openssh-server|\
 openvswitch-switch|\
 ovmf|\
 pacemaker|\
+python3-apt|\
 python3-ceph-argparse|\
 python3-cephfs|\
 python3-cffi-backend|\
@@ -62,6 +63,7 @@ qemu-block-extra|\
 qemu-utils|\
 snmpd|\
 sudo|\
+sysfsutils|\
 syslog-ng|\
 sysstat|\
 tuna|\

--- a/cukinia/hypervisor_security_tests.d/groups.conf
+++ b/cukinia/hypervisor_security_tests.d/groups.conf
@@ -56,7 +56,6 @@ groups=" \
     systemd-timesync \
     uuidd \
     ssh \
-    tcpdump \
     docker \
     Debian-snmp \
     libvirt \

--- a/cukinia/hypervisor_security_tests.d/passwd.conf
+++ b/cukinia/hypervisor_security_tests.d/passwd.conf
@@ -28,7 +28,6 @@ passwd=" \
     messagebus \
     systemd-timesync \
     uuidd \
-    tcpdump \
     sshd \
     Debian-snmp \
     libvirt-qemu \

--- a/cukinia/hypervisor_security_tests.d/shadow.conf
+++ b/cukinia/hypervisor_security_tests.d/shadow.conf
@@ -36,7 +36,6 @@ locked_users=" \
     messagebus \
     systemd-timesync \
     uuidd \
-    tcpdump \
     sshd \
     Debian-snmp \
     libvirt-qemu \


### PR DESCRIPTION
python3-cffi-backend is a dependency of ceph although it is not marked rdepends by apt-cache.

SFL: #8646
Change-Id: I40f14103f5dfa63ddb4fffc946bdf1c97ec83c4f