### PR TITLE
cukinia-tests: debian: hardening: test if private tmpdir exist

### DIFF
--- a/cukinia/common_security_tests.d/hardening.conf
+++ b/cukinia/common_security_tests.d/hardening.conf
@@ -63,3 +63,10 @@ as "SEAPATH-00203 - grub root superuser is password protected" \
 	cukinia_cmd grep -q "^password_pbkdf2 root grub.pbkdf2.sha512.65536.*$" /boot/grub/grub.cfg
 as "SEAPATH-00204 - main menuentry is unrestricted in /boot/grub/grub.cfg" \
 	cukinia_cmd grep -q "^menuentry.*--unrestricted" /boot/grub/grub.cfg
+
+# Check that $USER have a private $TMPDIR
+as "SEAPATH-00205 - TMPDIR env var is defined and readonly" cukinia_test \
+	$(bash -l -c 'readonly -p' | grep -E 'TMPDIR=*' | wc -l) -eq 1
+
+as "SEAPATH-00206 - TMPDIR is set with 700 mode and $USER as owner and group" cukinia_test\
+	"$(bash -l -c 'stat $TMPDIR -c "%a %U %G"')" = "700 $USER $USER"


### PR DESCRIPTION
 * Add test to check if TMPDIR is set with owner-only permissions