### PR TITLE
security: apt: allow configuring a proxy

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf
+++ b/cukinia/common_security_tests.d/apt.conf
@@ -1,12 +1,10 @@
 cukinia_log "$(_colorize yellow "--- check apt configuration ---")"
 
-OFFICIAL_REPOS="(\
-artifacts.elastic.co|\
-deb.debian.org|\
-download.docker.com|\
-ftp.fr.debian.org|\
-security.debian.org\
-)"
+OFFICIAL_REPOS="({{
+    apt_proxy
+    | default('artifacts.elastic.co|deb.debian.org|download.docker.com|ftp.fr.debian.org|security.debian.org')
+}})"
+
 # Awk exptression extract the repositorie's hostname
 # deb http://ftp.fr.debian.org/debian bullseye main contrib non-free --> ftp.fr.debian.org
 as "SEAPATH-00197 - Only official apt repositories configured" \


### PR DESCRIPTION
Use the jinja syntax to allow avoiding public repositories to use a proxy.

SFL: #9314
Change-Id: I35180a6bbad58c129ec6989b3209e97eda146a18