### PR TITLE
security: network: check for unbound sockets

### DIFF
--- a/cukinia/common_security_tests.d/network.conf
+++ b/cukinia/common_security_tests.d/network.conf
@@ -1,0 +1,15 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+cukinia_log "$(_colorize yellow "--- check network settings ---")"
+
+# sed expression prints the systemd service names through their cgroup
+# udp UNCONN 0 0 0.0.0.0:4789 0.0.0.0:* ino:15650 sk:1069 cgroup:/ovs.slice/ovs-vswitchd.service <-> --> ovs-vswitchd.service
+UNBOUND_SOCKETS="$(ss -ae4H 'src = 0.0.0.0 && dev = 0' | sed -e 's;^.*cgroup:.*.slice/\([^ ]*\).*;\1;')"
+
+if [ "$UNBOUND_SOCKETS" != "" ]; then
+    cukinia_log "$(_colorize red Unbound sockets: $UNBOUND_SOCKETS)"
+fi
+
+as "ANSSI-BP-028-R80 - All sockets are bound to an interface" \
+    cukinia_test "$(ss -ae4H 'src = 0.0.0.0 && dev = 0')" = ""


### PR DESCRIPTION
A socket is bound to an interface if any of these conditions are met:
 - it is bound to an IP (not 0.0.0.0)
 - it is bound to a device

Verifies compliance with ANSSI-BP-028-R80.

SFL: #8649
Change-Id: I1ab5a15e662e45fec2e998b2ed82595aa82044ca