### PR TITLE
vm_manager_rbd.conf: extend timeout

### DIFF
--- a/cukinia/cluster_tests.d/vm_manager_rbd.conf
+++ b/cukinia/cluster_tests.d/vm_manager_rbd.conf
@@ -3,16 +3,16 @@
 
 cukinia_log "$(_colorize yellow "--- Test vm_manager module Ceph RBD part ---")"
 
-as "SEAPATH-00056 - Test clone disk" cukinia_cmd timeout -k 5s 5s /usr/local/bin/clone_rbd.py
+as "SEAPATH-000306 - Test clone disk" cukinia_cmd timeout -k 30s 30s /usr/local/bin/clone_rbd.py
 
-as "SEAPATH-00057 - Test groups" cukinia_cmd timeout -k 5s 5s /usr/local/bin/create_rbd_group.py
+as "SEAPATH-000307 - Test groups" cukinia_cmd timeout -k 30s 30s /usr/local/bin/create_rbd_group.py
 
-as "SEAPATH-00058 - Test namespaces" cukinia_cmd timeout -k 5s 5s /usr/local/bin/create_rbd_namespace.py
+as "SEAPATH-000308 - Test namespaces" cukinia_cmd timeout -k 30s 30s /usr/local/bin/create_rbd_namespace.py
 
-as "SEAPATH-00059 - Test metadata" cukinia_cmd timeout -k 5s 5s /usr/local/bin/metadata_rbd.py
+as "SEAPATH-000309 - Test metadata" cukinia_cmd timeout -k 30s 30s /usr/local/bin/metadata_rbd.py
 
-as "SEAPATH-00060 - Test snapshots" cukinia_cmd timeout -k 30s 30s /usr/local/bin/purge_rbd.py
+as "SEAPATH-00060 - Test snapshots" cukinia_cmd timeout -k 60s 60s /usr/local/bin/purge_rbd.py
 
-as "SEAPATH-00061 - Test snapshots rollback" cukinia_cmd timeout -k 10s 10s /usr/local/bin/rollback_rbd.py
+as "SEAPATH-00061 - Test snapshots rollback" cukinia_cmd timeout -k 40s 40s /usr/local/bin/rollback_rbd.py
 
-as "SEAPATH-00062 - Test write rbd" cukinia_cmd timeout -k 5s 5s /usr/local/bin/write_rbd.py
+as "SEAPATH-00062 - Test write rbd" cukinia_cmd timeout -k 30s 30s /usr/local/bin/write_rbd.py


### PR DESCRIPTION
Previous timeout was too quick for ceph to properly build the images. This commit significantly extend the timeout.