### PR TITLE
 split and variabilize accounts used for rescue access and libvirt live-migration

### DIFF
--- a/cukinia/hypervisor_security_tests.d/groups.conf.j2
+++ b/cukinia/hypervisor_security_tests.d/groups.conf.j2
@@ -64,7 +64,7 @@ groups=" \
     privileged \
     ansible \
     _chrony \
-    virtu \
+    {{ admin_user }} \
 "
 args="-v"
 for g in ${groups}; do

--- a/cukinia/hypervisor_security_tests.d/passwd.conf.j2
+++ b/cukinia/hypervisor_security_tests.d/passwd.conf.j2
@@ -34,7 +34,8 @@ passwd=" \
     systemd-coredump \
     ansible \
     _chrony \
-    virtu \
+    {{ admin_user }} \
+    {{ livemigration_user }} \
     libvirt \
 "
 args="-v"

--- a/cukinia/hypervisor_security_tests.d/shadow.conf.j2
+++ b/cukinia/hypervisor_security_tests.d/shadow.conf.j2
@@ -5,7 +5,7 @@ cukinia_log "$(_colorize yellow "--- check /etc/shadow ---")"
 
 unlocked_users=" \
     root \
-    virtu \
+    {{ admin_user }} \
 "
 
 locked_users=" \
@@ -41,6 +41,7 @@ locked_users=" \
     libvirt-qemu \
     systemd-coredump \
     _chrony \
+    {{ livemigration_user }} \
 "
 
 ret=0


### PR DESCRIPTION
This is to go with https://github.com/seapath/ansible/pull/255
