### PR TITLE
kernel.conf: correct app armor test

### DIFF
--- a/cukinia/common_security_tests.d/kernel.conf
+++ b/cukinia/common_security_tests.d/kernel.conf
@@ -42,4 +42,4 @@ as "SEAPATH-00211 - rng_core.default_quality is set to 500" cukinia_cmd \
 	grep -q "rng_core.default_quality=500" /proc/cmdline
 
 as "SEAPATH-00226 - Test AppArmor is enabled " \
-  cukinia_test "$(aa-enabled)" == "Yes"
+  cukinia_test "$(cat /sys/module/apparmor/parameters/enabled)" == "Y"


### PR DESCRIPTION
This is the standard way to test if apparmor is enabled according to debian wiki.
https://wiki.debian.org/AppArmor/HowToUse