### PR TITLE
vm-mgr api: adapts tests + fix services list bug

### DIFF
--- a/cukinia/common_security_tests.d/files.conf
+++ b/cukinia/common_security_tests.d/files.conf
@@ -24,7 +24,7 @@ as "SEAPATH-00192 - All files have a known owner and group" \
 as "SEAPATH-00193 - All directories writable by all users have the sticky bit" \
     cukinia_test "$(find / -type d \( -perm -0002 -a \! -perm -1000 \) 2>/dev/null || true)" = ""
 as "SEAPATH-00194 - All directories writable by all users are owned by root" \
-    cukinia_test "$(find / -type d -perm -0002 -a \! -uid 0 -not -path '/var/lib/ceph/osd/*' 2>/dev/null || true)" = ""
+    cukinia_test "$(find / -type d -perm -0002 -a \! -uid 0 -not -path '/var/lib/ceph/osd/*' -not -path '/var/lib/docker/overlay2/*' 2>/dev/null || true)" = ""
 # Ceph is an exception because the ceph daemon controls the osd filesystem
 as "SEAPATH-00195 - Ceph OSD are owned by ceph" \
     cukinia_test "$(find /var/lib/ceph/osd -type d -perm -0002 -a \! -user ceph 2>/dev/null || true)" = ""

--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -79,7 +79,9 @@ user-runtime-dir|\
 user|\
 virtlogd|\
 votp-config_ovs|\
-votp-taskset\
+votp-taskset|\
+vmmgrapidocker|\
+vmmgrapipiperun\
 )"
 
 UNRECOGNIZED_SERVICES="$(systemctl list-units --type service --plain --no-pager --no-legend | awk -F ' ' '{ print $1}' | grep -Ev '^'${ESSENTIAL_SERVICES}'(@.*)?'.service'$')"

--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -14,6 +14,7 @@ ceph-crash|\
 ceph-mgr|\
 ceph-mon|\
 ceph-osd|\
+chrony-wait|\
 console-setup|\
 containerd|\
 corosync|\
@@ -35,10 +36,11 @@ lvm2-pvscan|\
 netfilter-persistent|\
 openipmi|\
 openvswitch-switch|\
-ovs-record-hostname.service\|
+ovs-record-hostname|\
 ovs-vswitchd|\
 ovsdb-server|\
 pacemaker|\
+polkit|\
 ptp_vsock|\
 ptpstatus|\
 rbdmap|\
@@ -50,14 +52,14 @@ sysfsutils|\
 syslog-ng|\
 sysstat|\
 systemd-backlight|\
-systemd-binfmt.service\|
+systemd-binfmt|\
 systemd-fsck|\
 systemd-journal-flush|\
 systemd-journald|\
 systemd-logind|\
 systemd-machined|\
 systemd-modules-load|\
-systemd-network-generator.service\|
+systemd-network-generator|\
 systemd-networkd-wait-online|\
 systemd-networkd|\
 systemd-random-seed|\


### PR DESCRIPTION
Adding the vm-mgr http api (https://github.com/seapath/ansible/pull/317) requires:
- that docker overlay files be considered an exception to test 00194
- 2 new systemd services (vmmgrapipiperun and vmmgrapidocker)

Also, this commit fixes a bug in the list of essential services, where the string |\ had be wrongly typed \\| .
This make the whole "grep" operation fail, and the test was successful all the time... Correcting this bug led to discover that a few essential services (polkit, chrony-wait...) had be either forgotten or entered with the ".service" extension, which is wrong. This commit fixes all that.