### PR TITLE
systemd.conf: fix services list bug + docker overlay exception

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -51,7 +51,6 @@ libvirt-clients|\
 libvirt-daemon-driver-storage-rbd|\
 libvirt-daemon-system|\
 libvirt-daemon|\
-linux-image-6.0.0-0.deb11.6-rt-amd64|\
 linux-image-rt-amd64|\
 linuxptp|\
 lm-sensors|\
@@ -137,7 +136,6 @@ libpam-modules-bin|\
 libpam-modules|\
 libpam-runtime|\
 libreadline8|\
-linux-image-amd64|\
 login|\
 logrotate|\
 mawk|\

--- a/cukinia/common_security_tests.d/files.conf
+++ b/cukinia/common_security_tests.d/files.conf
@@ -24,7 +24,7 @@ as "SEAPATH-00192 - All files have a known owner and group" \
 as "SEAPATH-00193 - All directories writable by all users have the sticky bit" \
     cukinia_test "$(find / -type d \( -perm -0002 -a \! -perm -1000 \) 2>/dev/null || true)" = ""
 as "SEAPATH-00194 - All directories writable by all users are owned by root" \
-    cukinia_test "$(find / -type d -perm -0002 -a \! -uid 0 -not -path '/var/lib/ceph/osd/*' 2>/dev/null || true)" = ""
+    cukinia_test "$(find / -type d -perm -0002 -a \! -uid 0 -not -path '/var/lib/ceph/osd/*' -not -path '/var/lib/docker/overlay2/*' 2>/dev/null || true)" = ""
 # Ceph is an exception because the ceph daemon controls the osd filesystem
 as "SEAPATH-00195 - Ceph OSD are owned by ceph" \
     cukinia_test "$(find /var/lib/ceph/osd -type d -perm -0002 -a \! -user ceph 2>/dev/null || true)" = ""

--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -14,6 +14,7 @@ ceph-crash|\
 ceph-mgr|\
 ceph-mon|\
 ceph-osd|\
+chrony-wait|\
 console-setup|\
 containerd|\
 corosync|\
@@ -35,10 +36,11 @@ lvm2-pvscan|\
 netfilter-persistent|\
 openipmi|\
 openvswitch-switch|\
-ovs-record-hostname.service\|
+ovs-record-hostname|\
 ovs-vswitchd|\
 ovsdb-server|\
 pacemaker|\
+polkit|\
 ptp_vsock|\
 ptpstatus|\
 rbdmap|\
@@ -50,14 +52,14 @@ sysfsutils|\
 syslog-ng|\
 sysstat|\
 systemd-backlight|\
-systemd-binfmt.service\|
+systemd-binfmt|\
 systemd-fsck|\
 systemd-journal-flush|\
 systemd-journald|\
 systemd-logind|\
 systemd-machined|\
 systemd-modules-load|\
-systemd-network-generator.service\|
+systemd-network-generator|\
 systemd-networkd-wait-online|\
 systemd-networkd|\
 systemd-random-seed|\


### PR DESCRIPTION
systemd.conf: fix services list bug

This commit fixes a bug in the list of essential services, where the string |\ had be wrongly typed \|
This make the whole "grep" operation fail, and the test was successful all the time... 
Correcting this bug led to discover that a few essential services (polkit, chrony-wait...) had be either forgotten or entered with the ".service" extension, which is wrong. 
This commit fixes all that.

----
SEAPATH-00194: add overlay2 exception

Docker overlay files have the drwxrwxrwt permission which matches test 00194 (writable by world, but not belonging to root user).

The world writable permission is harmless because the parent directories are protected against unwanted access (the executable bit is turned off) and so the directories cannot be traversed/accessed to arrive to such world-writable directories or files.

https://www.ibm.com/support/pages/some-icp-filesdirectories-are-created-world-writable-permission

----
package list: leave only linux-image-rt-amd64 for kernel