### PR TITLE
hypervisor_tests.d/virtualization: fix libvirtd test

### DIFF
--- a/cukinia/hypervisor_tests.d/virtualization.conf
+++ b/cukinia/hypervisor_tests.d/virtualization.conf
@@ -1,10 +1,11 @@
 # Copyright (C) 2020, RTE (http://www.rte-france.com)
+# Copyright (C) 2024 Savoir-faire Linux, Inc
 # SPDX-License-Identifier: Apache-2.0
 
 cukinia_log "$(_colorize yellow "--- check that the virtualization can run ---")"
 as "SEAPATH-00018 - KVM device available" cukinia_test -c /dev/kvm
 as "SEAPATH-00019 - Qemu for x86-64 available" cukinia_cmd qemu-system-x86_64 --version
-as "SEAPATH-00020 - Libvirtd service is running" cukinia_cmd systemctl is-active libvirtd
+as "SEAPATH-00020 - Libvirtd service is running" cukinia_cmd systemctl is-active libvirtd.socket
 as "SEAPATH-00021 - IPv4 NAT is available" cukinia_cmd iptables -t nat -L
 if [ -d /proc/sys/net/ipv6 ] ; then
     as "SEAPATH-00022 - IPv6 NAT is available" cukinia_cmd ip6tables -t nat -L


### PR DESCRIPTION
The test for libvirtd service was checking if the service was active instead of the socket. This is a mistake as the service is not necessarily active when the socket is.