### PR TITLE
cukinia/configurations: correct section names

### DIFF
--- a/cukinia/configurations/cukinia-common-security.conf
+++ b/cukinia/configurations/cukinia-common-security.conf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 logging class "${MACHINENAME:-$(hostname)}"
-logging suite common_security
+logging suite "common security"
 cukinia_conf_include /etc/cukinia/common_security_tests.d/*.conf

--- a/cukinia/configurations/cukinia-hypervisor-iommu.conf
+++ b/cukinia/configurations/cukinia-hypervisor-iommu.conf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 logging class "${MACHINENAME:-$(hostname)}"
-logging suite hypervisor-iommu
+logging suite "hypervisor iommu"
 cukinia_conf_include /etc/cukinia/hypervisor_iommu_tests.d/*.conf

--- a/cukinia/configurations/cukinia-hypervisor-security.conf
+++ b/cukinia/configurations/cukinia-hypervisor-security.conf
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 logging class "${MACHINENAME:-$(hostname)}"
-logging suite hypervisor-security
+logging suite "hypervisor security"
 cukinia_conf_include /etc/cukinia/hypervisor_security_tests.d/*.conf


### PR DESCRIPTION
To appear correctly in the pdf report generated by the CI, the section names with multiple word should use double quotes and a space.