### PR TITLE
systemd.conf: rename votp-taskset service.

### DIFF
--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -80,7 +80,7 @@ user-runtime-dir|\
 user|\
 virtlogd|\
 votp-config_ovs|\
-votp-taskset\
+kthread-taskset\
 )"
 
 UNRECOGNIZED_SERVICES="$(systemctl list-units --type service --plain --no-pager --no-legend | awk -F ' ' '{ print $1}' | grep -Ev '^'${ESSENTIAL_SERVICES}'(@.*)?'.service'$')"


### PR DESCRIPTION
In order to get rid of votp, this service is now renamed "kthread-taskset".