### PR TITLE
hypervisor_security_tests.d: make livemigration user optionnal

### DIFF
--- a/cukinia/hypervisor_security_tests.d/passwd.conf.j2
+++ b/cukinia/hypervisor_security_tests.d/passwd.conf.j2
@@ -32,7 +32,9 @@ passwd=" \
     ansible \
     _chrony \
     {{ admin_user }} \
+{% if livemigration_user is defined %}
     {{ livemigration_user }} \
+{% endif %}
     libvirt \
 {% if ansible_distribution == 'Debian' and ansible_distribution_version | int < 12 %}
     gnats \

--- a/cukinia/hypervisor_security_tests.d/shadow.conf.j2
+++ b/cukinia/hypervisor_security_tests.d/shadow.conf.j2
@@ -44,7 +44,9 @@ locked_users=" \
     libvirt-qemu \
     systemd-coredump \
     _chrony \
+{% if livemigration_user is defined %}
     {{ livemigration_user }} \
+{% endif %}
 "
 
 ret=0


### PR DESCRIPTION
When no livemigration_user is defined, the template fails. This commit corrects it by templating the livemigration user only if it is defined in the inventory.