### PR TITLE
add conntrackd package

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -29,6 +29,7 @@ ceph-mon|\
 ceph-osd|\
 ceph|\
 chrony|\
+conntrackd|\
 corosync|\
 cpuset|\
 crmsh|\

--- a/cukinia/common_security_tests.d/network.conf
+++ b/cukinia/common_security_tests.d/network.conf
@@ -5,14 +5,15 @@ cukinia_log "$(_colorize yellow "--- check network settings ---")"
 
 # sed expression prints the systemd service names through their cgroup
 # udp UNCONN 0 0 0.0.0.0:4789 0.0.0.0:* ino:15650 sk:1069 cgroup:/ovs.slice/ovs-vswitchd.service <-> --> ovs-vswitchd.service
-UNBOUND_SOCKETS="$(ss -ae4H 'src = 0.0.0.0 && dev = 0' | sed -e 's;^.*cgroup:.*.slice/\([^ ]*\).*;\1;')"
+# We make an exception for conntrackd that cannot bind to a specific address (https://salsa.debian.org/pkg-netfilter-team/pkg-conntrack-tools/-/blob/master/src/mcast.c?ref_type=heads#L56)
+UNBOUND_SOCKETS="$(ss -ae4H 'src = 0.0.0.0 && dev = 0' | sed -e 's;^.*cgroup:.*.slice/\([^ ]*\).*;\1;' | grep -v conntrackd.service)"
 
 if [ "$UNBOUND_SOCKETS" != "" ]; then
     cukinia_log "$(_colorize red Unbound sockets: $UNBOUND_SOCKETS)"
 fi
 
 id "SEAPATH-00223" as "All sockets are bound to an interface" \
-    cukinia_test "$(ss -ae4H 'src = 0.0.0.0 && dev = 0')" = ""
+    cukinia_test "$(ss -ae4H 'src = 0.0.0.0 && dev = 0' | grep -v conntrackd.service)" = ""
 
 id "SEAPATH-00224" as "IPv6 is disabled" \
     cukinia_cmdline ipv6.disable=1

--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -16,6 +16,7 @@ ceph-mon|\
 ceph-osd|\
 chrony-wait|\
 console-setup|\
+conntrackd|\
 containerd|\
 corosync|\
 cron|\


### PR DESCRIPTION
We also add an exception to the UNBOUND_SOCKETS rules, because conntrackd cannot bind to a specific address

https://salsa.debian.org/pkg-netfilter-team/pkg-conntrack-tools/-/blob/master/src/mcast.c?ref_type=heads#L56