### PR TITLE
systemd.conf: add netplan package

### DIFF
--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -35,6 +35,7 @@ logd|\
 lvm2-monitor|\
 lvm2-pvscan|\
 netfilter-persistent|\
+netplan|\
 nginx|\
 openipmi|\
 openvswitch-switch|\


### PR DESCRIPTION
Netplan will now be used as a high level network configuration tool for SEAPATH.