### PR TITLE
systemd.conf: add netplan package

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -49,6 +49,7 @@ iucode-tool|\
 jq|\
 lbzip2|\
 libcephfs2|\
+libnetplan0|\
 libvirt-clients|\
 libvirt-daemon-driver-storage-rbd|\
 libvirt-daemon-system|\
@@ -59,6 +60,7 @@ linuxptp|\
 lm-sensors|\
 lsb-release|\
 net-tools|\
+netplan.io|\
 nginx|\
 ntfs-3g|\
 openssh-server|\
@@ -69,8 +71,12 @@ python3-apt|\
 python3-ceph-argparse|\
 python3-cephfs|\
 python3-cffi-backend|\
-python3-setuptools|\
 python3-flaskext.wtf|\
+python3-markdown-it|\
+python3-mdurl|\
+python3-pygments|\
+python3-rich|\
+python3-setuptools|\
 qemu-block-extra|\
 qemu-utils|\
 snmpd|\


### PR DESCRIPTION
Netplan will now be used as a high level network configuration tool for SEAPATH.