### PR TITLE
Add sleep for file deletion test + add vm_manager testdata

### DIFF
--- a/cukinia/common_security_tests.d/auditd.conf
+++ b/cukinia/common_security_tests.d/auditd.conf
@@ -48,7 +48,7 @@ for syscall in ${syscall_list}; do
         grep -q "$syscall" /var/log/audit/audit.log
 done
 
-rm /etc/cukinia-auditd-test
+rm /etc/cukinia-auditd-test ; sleep 0.1
 id "SEAPATH-00221" as "file deletion is logged" cukinia_cmd \
     grep -q ".*\/etc\/cukinia-auditd-test.*DELETE" /var/log/audit/audit.log
 

--- a/vm_manager_testdata/vm.xml
+++ b/vm_manager_testdata/vm.xml
@@ -1,0 +1,17 @@
+<domain type="qemu">
+  <name>test0</name>
+  <uuid>7b48b1fe-066a-41a6-aef4-f0a9c028f719</uuid>
+  <memory unit="KiB">32768</memory>
+  <os>
+    <type arch="x86_64" machine="pc-q35-4.1">hvm</type>
+  </os>
+  <cpu mode="host-model" check="full"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+  </devices>
+</domain>

--- a/vm_manager_testdata/wrong_vm_config.xml
+++ b/vm_manager_testdata/wrong_vm_config.xml
@@ -1,0 +1,15 @@
+<domain type="qemu">
+  <memory unit="KiB">32768</memory>
+  <os>
+    <type arch="x86_64" machine="pc-q35-4.1">hvm</type>
+  </os>
+  <cpu mode="host-model" check="full"/>
+  <clock offset="utc">
+    <timer name="rtc" tickpolicy="catchup"/>
+    <timer name="pit" tickpolicy="delay"/>
+    <timer name="hpet" present="no"/>
+  </clock>
+  <devices>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
+  </devices>
+</domain>


### PR DESCRIPTION
Add sleep for file deletion test

This test often fail. I assume it's because the log hasn't had time to be written when the test checks.
This commits adds a delay.

----
add vm_manager testdata