### PR TITLE
apt.conf: add libxml2-utils to the list of packages

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -54,6 +54,7 @@ libvirt-clients|\
 libvirt-daemon-driver-storage-rbd|\
 libvirt-daemon-system|\
 libvirt-daemon|\
+libxml2-utils|\
 linux-image-rt-amd64|\
 linux-perf|\
 linuxptp|\


### PR DESCRIPTION
libxml2-utils is added by this PR: https://github.com/seapath/build_debian_iso/pull/117.