### PR TITLE
add team0_x service + remove PAGE_TABLE_ISOLATION and RETPOLINE kernel checks

### DIFF
--- a/cukinia/common_security_tests.d/kernel.conf
+++ b/cukinia/common_security_tests.d/kernel.conf
@@ -8,8 +8,6 @@ unset kernel_options && declare -A kernel_options
 kernel_options["hardening"]="SECURITY_YAMA:y                   \
                              DEBUG_WX:y                        \
                              SECURITY_DMESG_RESTRICT:y         \
-                             PAGE_TABLE_ISOLATION:y            \
-                             RETPOLINE:y                       \
                              LEGACY_VSYSCALL_NONE:y            \
                              SLAB_FREELIST_RANDOM:y            \
                              SLAB_FREELIST_HARDENED:y          \

--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -76,6 +76,7 @@ systemd-udevd|\
 systemd-update-utmp|\
 systemd-update-utmp-runlevel|\
 systemd-user-sessions|\
+team0_x|\
 timemaster|\
 tuned|\
 user-runtime-dir|\


### PR DESCRIPTION
add team0_x service
Usefull to deal with RSTP/Corosync working together (https://github.com/seapath/ansible/pull/666)

----
remove PAGE_TABLE_ISOLATION and RETPOLINE kernel checks
On v6.11 (tested with debian bpo kernel), those options are not included anymore.