### PR TITLE
use deb822 repos

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -3,14 +3,14 @@ cukinia_log "$(_colorize yellow "--- check apt configuration ---")"
 
 {% if apt_repo is defined %}
 id "SEAPATH-00197" as "Only wanted apt repositories configured: only use sources.list" \
-    cukinia_test -z "$(ls /etc/apt/sources.list.d/)"
+    cukinia_test -z "$(ls /etc/apt/sources.list)"
 
 id "SEAPATH-00197" as "Only wanted apt repositories configured: do not add other repositories" \
-    cukinia_test $(cat /etc/apt/sources.list |wc -l) -eq {{ apt_repo | length }}
+    cukinia_test $(ls /etc/apt/sources.list.d | wc -l) -eq {{ apt_repo | length }}
 
 {% for repo in apt_repo %}
-id "SEAPATH-00197" as "Only official apt repositories configured: {{ repo }}" \
-    cukinia_cmd  grep -Eq "^deb {{ repo }}$" /etc/apt/sources.list
+id "SEAPATH-00197" as "Only official apt repositories configured: {{ repo.name }}" \
+    cukinia_cmd  grep -Eq "^URIs: {{ repo.uris }}$" /etc/apt/sources.list.d/{{ repo.name }}.sources
 {% endfor %}
 {% endif %}
 
@@ -76,6 +76,7 @@ python3-apt|\
 python3-ceph-argparse|\
 python3-cephfs|\
 python3-cffi-backend|\
+python3-debian|\
 python3-flaskext.wtf|\
 python3-markdown-it|\
 python3-mdurl|\


### PR DESCRIPTION
This commits changes the way the debian repos are verified, according to the deb822 format. Also the ansible module needs python3-debian.