### PR TITLE
apt: allow the patch package

### DIFF
--- a/cukinia/common_security_tests.d/apt.conf.j2
+++ b/cukinia/common_security_tests.d/apt.conf.j2
@@ -72,6 +72,7 @@ openssh-server|\
 openvswitch-switch|\
 ovmf|\
 pacemaker|\
+patch|\
 python3-apt|\
 python3-ceph-argparse|\
 python3-cephfs|\


### PR DESCRIPTION
This package is useful for an upcoming PR ("grub bootcount") where we have to patch the /etc/grub.d/10-setup file.