### PR TITLE
disable iommu in vm + allow rc.local

### DIFF
--- a/cukinia/common_security_tests.d/systemd.conf
+++ b/cukinia/common_security_tests.d/systemd.conf
@@ -47,6 +47,7 @@ polkit|\
 ptp_vsock|\
 ptpstatus|\
 rbdmap|\
+rc.local|\
 serial-getty@ttyS0|\
 smartmontools|\
 snmpd|\

--- a/cukinia/hypervisor_iommu_tests.d/iommu.conf
+++ b/cukinia/hypervisor_iommu_tests.d/iommu.conf
@@ -7,8 +7,8 @@ cukinia_log "$(_colorize yellow "--- check iommu status ---")"
 id "SEAPATH-00030" as "iommu enabled in passthrough mode" cukinia_cmd \
     grep -q "iommu=pt" /proc/cmdline
 
-# Check that iommu is loaded in system
-id "SEAPATH-00031" as "iommu is loaded" cukinia_cmd find /sys/class/iommu/*
+# Check that iommu is loaded in system, unless we already run inside a VM
+[[ "$(systemd-detect-virt)" == "none" ]] && id "SEAPATH-00031" as "iommu is loaded" cukinia_cmd find /sys/class/iommu/*
 
-# Check that iommu groups are populated
-id "SEAPATH-00032" as "iommu is populated" cukinia_cmd find /sys/kernel/iommu_groups/*
+# Check that iommu groups are populated, unless we already run inside a VM
+[[ "$(systemd-detect-virt)" == "none" ]] && id "SEAPATH-00032" as "iommu is populated" cukinia_cmd find /sys/kernel/iommu_groups/*


### PR DESCRIPTION
iommu: disable check if we run inside a VM

This is useful for virtualized CI server, used only for code validation.

----
systemd: allow rc.local service

This is useful for a user to customize the boot process by adding stuff to rc.local